### PR TITLE
Added integration API and lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,10 @@ dependencies {
     compile fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}")
     implementation fg.deobf("curse.maven:mekanism-268560:3206392")
     runtimeOnly fg.deobf("curse.maven:theoneprobe-245211:3157997")
+
+    //lombok
+    compileOnly 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
 }
 
 shadowJar {

--- a/src/main/java/software/bernie/techarium/integration/Integration.java
+++ b/src/main/java/software/bernie/techarium/integration/Integration.java
@@ -1,0 +1,43 @@
+package software.bernie.techarium.integration;
+
+import net.minecraftforge.fml.ModList;
+
+public abstract class Integration {
+    private final String modID;
+
+    protected Integration(String modID) {
+        this.modID = modID;
+    }
+
+    public boolean isPresent() {
+        return ModList.get().isLoaded(this.getModID());
+    }
+
+    public String getModID() {
+        return this.modID;
+    }
+
+    public static class Wrapper<T extends Integration> {
+        private final T integration;
+
+        public static <T extends Integration> Wrapper<T> of(T integration) {
+            return new Wrapper(integration);
+        }
+
+        public Wrapper(T integration) {
+            this.integration = integration;
+        }
+
+        public boolean isPresent() {
+            return integration.isPresent();
+        }
+
+        public T get() {
+            if (isPresent()) {
+                return this.integration;
+            } else {
+                throw new ModIntegrationException(integration.getModID());
+            }
+        }
+    }
+}

--- a/src/main/java/software/bernie/techarium/integration/ModIntegrationException.java
+++ b/src/main/java/software/bernie/techarium/integration/ModIntegrationException.java
@@ -1,0 +1,8 @@
+package software.bernie.techarium.integration;
+
+public class ModIntegrationException extends RuntimeException {
+
+    public ModIntegrationException(String modID) {
+        super("Mod: " + modID + " is not present, cannot use integration!");
+    }
+}

--- a/src/main/java/software/bernie/techarium/integration/ModIntegrations.java
+++ b/src/main/java/software/bernie/techarium/integration/ModIntegrations.java
@@ -1,0 +1,8 @@
+package software.bernie.techarium.integration;
+
+import software.bernie.techarium.integration.mekanism.MekanismIntegration;
+
+public class ModIntegrations {
+    public static final Integration.Wrapper<MekanismIntegration> MEKANISM = Integration.Wrapper.of(
+            new MekanismIntegration("mekanism"));
+}

--- a/src/main/java/software/bernie/techarium/integration/mekanism/MekanismIntegration.java
+++ b/src/main/java/software/bernie/techarium/integration/mekanism/MekanismIntegration.java
@@ -1,0 +1,19 @@
+package software.bernie.techarium.integration.mekanism;
+
+import mekanism.common.registries.MekanismItems;
+import net.minecraft.item.Item;
+import software.bernie.techarium.integration.Integration;
+
+/**
+ * Anything in this class is safe to use without worrying about ClassNotfound's, the Wrapper takes care of the overhead
+ */
+public class MekanismIntegration extends Integration {
+    public MekanismIntegration(String modID) {
+        super(modID);
+    }
+
+    public boolean isGauge(Item item)
+    {
+        return item == MekanismItems.GAUGE_DROPPER.getItem();
+    }
+}


### PR DESCRIPTION
This PR adds `ModIntegrations`, which will have a bunch of wrappers for integrations that are protected against ClassNotFounds and let you gracefully check if the mod is present. There's also an exception for if you forgot to check if the mod is present and try to use the integration directly.