### PR TITLE
Fix ShadowJar not including shadowed dependencies in CI builds.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --info

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.1.+', changing: true
-        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.4'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
         classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-SNAPSHOT'
     }
 }
@@ -125,11 +125,11 @@ dependencies {
     //Geckolib
     implementation fg.deobf("software.bernie.geckolib:${geckolib_version}")
 
-    //adventure
-    implementation "net.kyori:adventure-api:$adventure_version"
-    implementation "net.kyori:adventure-text-serializer-gson:$adventure_version"
-    implementation "net.kyori:adventure-text-serializer-legacy:$adventure_version"
-    implementation "net.kyori:adventure-text-serializer-plain:$adventure_version"
+    //Kyori Adventure Deps. Must be shadowed into the final jar
+    shadow implementation("net.kyori:adventure-api:$adventure_version")
+    shadow implementation("net.kyori:adventure-text-serializer-gson:$adventure_version")
+    shadow implementation("net.kyori:adventure-text-serializer-legacy:$adventure_version")
+    shadow implementation("net.kyori:adventure-text-serializer-plain:$adventure_version")
 
     //Integration mods
     compileOnly fg.deobf("mezz.jei:jei-${jei_mc_version}:${jei_version}:api")
@@ -177,7 +177,8 @@ if (System.getProperty("idea.sync.active") == "true") {
 // Populates mods.toml file with gradle variables. Reference: https://github.com/SizableShrimp/ForgeTemplate/blob/1.16.x/build.gradle#L158-L188
 def resource_targets = ["META-INF/mods.toml", "pack.mcmeta"]
 task replaceResources(type: Copy) {
-    dependsOn(jar)
+    //Comment out dependency on jar process. This fixes an issue where this task is run too late when other projects use Techarium as a dependency.
+    //dependsOn(jar)
     outputs.upToDateWhen { false }
     def spec = copySpec {
         from(sourceSets.main.resources) {
@@ -235,12 +236,14 @@ task createBuildscriptProperties(type: Copy) {
 }
 
 shadowJar {
-    dependencies {
-        include(dependency('net.kyori:.*'))
-    }
-    relocate 'net.kyori', 'software.bernie.shadowed.net.kyori'
-
     classifier ''
+    configurations = [project.configurations.shadow]
+
+    //Disable the use of include dependency due to use of the shadow configuration. Do not uncomment this, this will break shadow jar.
+    //dependencies {
+    //    include(dependency('net.kyori:.*'))
+    //}
+    relocate 'net.kyori', 'software.bernie.shadowed.net.kyori'
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,5 +47,5 @@ farmers_delight_version=3310983
 oh_the_biomes_youll_go_version=3337158
 biomes_o_plenty_version=3360574
 cofh_core_version=1.16.4-1.2.0
-immersive_engineering_version=1.16.5-4.2.4-134.7
+immersive_engineering_version=1.16.5-5.0.2-137
 discord_webhooks_version=0.5.7


### PR DESCRIPTION
This PR fixes an issue with the buildscript from not including shadowed project dependencies when being built from CI. 

### Issue Description
Prior to this fix, only jars built on local machines would be able to include the shadowed dependencies.
The lack of shadowed dependencies caused runtime crashes for users.

The need to address this issue is important because the jars built from CI are being distributed to end users on each new commit on the master branch. It is critical that CI builds are working so that developers can save time from needing to make manual builds.

### Changes
- Switch the shadowjar project configuration to use the shadow
configuration
- Disabled use of ``include dependency`` in shadowJar block. The change in project configuration causes the ``include dependency`` to break the shadow jar behaviour.
- Bumped Shadow Jar version to 6.1.0
- Comment out dependency of jar process task in ``replaceResources`` task. This fixes an issue that can occur where the task runs too late when other projects depend on Techarium. If this happens, the mods.toml file is not populated, which will prevent the mod from being loaded.
- Added the ``--info`` flag to the github actions workflow build step. This allows us to debug CI builds better in the future.
- Update Immersive Engineering version to 5.0.2-137 to fix runtime crash in a dev environment caused by conflicting method name used by IE. This was required in order to verify this shadow jar fix was working.

### Testing and Validation
We can validate that this fix works through using debug flags such as ``--info`` added during gradle building.

Before this fix, the ShadowJar task listed only 8 Jars being included as shown below.
<img width="700" alt="previous_build" src="https://user-images.githubusercontent.com/22887654/126024092-54e1e561-9ce2-4e85-9eb3-f06a12f0e605.png">
This jar does not include any shadowed dependencies. The lack of a "shadowed" folder, which the buildscript specifies as the valid location, indicates no dependencies were shadowed.
<img width="959" alt="shadowed_failed" src="https://user-images.githubusercontent.com/22887654/126024269-8e3b7c4b-d9af-4cda-a78e-e8f1869d74ab.png">


After this fix, the ShadowJar task lists 9 Jars being included. The new build includes the Kyori Adventure and Examination dependencies as shown below.
<img width="846" alt="new_buildscript" src="https://user-images.githubusercontent.com/22887654/126024109-42005cb0-8863-4a2d-b23a-3591d9c57886.png">

<img width="960" alt="shadowed_success" src="https://user-images.githubusercontent.com/22887654/126024265-c23425a6-af29-4573-b0ba-d95fbbed3206.png">


We can also confirm that jars build through Github also include the shadowed dependencies using the same debug information.
<img width="960" alt="github_validate" src="https://user-images.githubusercontent.com/22887654/126024142-6f8f43ed-f951-4d00-b780-43afbe5452af.png">


If you have any questions please feel free to contact me.
If there's any further issues please let me know, I would be happy to address them.